### PR TITLE
Thread Options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ LOAD httpserver;
 
 ### 🔌 Usage
 Start the HTTP server providing the `host`, `port` and `auth` parameters.<br>
-> * If you want no authhentication, just pass an empty string as parameter.<br>
+> * If you want no authentication, just pass an empty string as parameter.<br>
 > * If you want the API run in foreground set `DUCKDB_HTTPSERVER_FOREGROUND=1`
 
 #### Basic Auth

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,8 @@ LOAD httpserver;
 
 ### 🔌 Usage
 Start the HTTP server providing the `host`, `port` and `auth` parameters.<br>
-> If you want no authhentication, just pass an empty string.
+> * If you want no authhentication, just pass an empty string as parameter.<br>
+> * If you want the API run in foreground set `DUCKDB_HTTPSERVER_FOREGROUND=1`
 
 #### Basic Auth
 ```sql

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -389,23 +389,7 @@ void HttpServerStart(DatabaseInstance& db, string_t host, int32_t port, string_t
 
     if (run_in_same_thread) {
 #ifdef _WIN32
-        // Windows-specific handler for Ctrl+C
-        BOOL WINAPI consoleHandler(DWORD signal) {
-            if (signal == CTRL_C_EVENT) {
-                if (global_state.server) {
-                    global_state.server->stop();
-                }
-                global_state.is_running = false; // Update the running state
-                return TRUE; // Indicate that the signal was handled
-            }
-            return FALSE;
-        }
-    
-        // Set the console control handler for Windows
-        if (!SetConsoleCtrlHandler(consoleHandler, TRUE)) {
-            std::cerr << "Error setting up signal handler" << std::endl;
-            throw IOException("Failed to set up signal handler");
-        }
+        throw IOException("Foreground mode not yet supported on WIN32 platforms.");
 #else
         // POSIX signal handler for SIGINT (Linux/macOS)
         signal(SIGINT, [](int) {
@@ -414,14 +398,14 @@ void HttpServerStart(DatabaseInstance& db, string_t host, int32_t port, string_t
             }
             global_state.is_running = false; // Update the running state
         });
-#endif
-    
+        
         // Run the server in the same thread
         if (!global_state.server->listen(host_str.c_str(), port)) {
             global_state.is_running = false;
             throw IOException("Failed to start HTTP server on " + host_str + ":" + std::to_string(port));
         }
-    
+#endif
+
         // The server has stopped (due to CTRL-C or other reasons)
         global_state.is_running = false;
     } else {

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -383,12 +383,26 @@ void HttpServerStart(DatabaseInstance& db, string_t host, int32_t port, string_t
     });
 
     string host_str = host.GetString();
-    global_state.server_thread = make_uniq<std::thread>([host_str, port]() {
+    
+    const char* run_in_same_thread_env = std::getenv("DUCKDB_HTTPSERVER_FOREGROUND");
+    bool run_in_same_thread = (run_in_same_thread_env != nullptr && std::string(run_in_same_thread_env) == "1");
+
+    if (run_in_same_thread) {
+        // Run the server in the same thread
         if (!global_state.server->listen(host_str.c_str(), port)) {
             global_state.is_running = false;
             throw IOException("Failed to start HTTP server on " + host_str + ":" + std::to_string(port));
         }
-    });
+    } else {
+        // Run the server in a dedicated thread (default)
+        global_state.server_thread = make_uniq<std::thread>([host_str, port]() {
+            if (!global_state.server->listen(host_str.c_str(), port)) {
+                global_state.is_running = false;
+                throw IOException("Failed to start HTTP server on " + host_str + ":" + std::to_string(port));
+            }
+        });
+    }
+    
 }
 
 void HttpServerStop() {


### PR DESCRIPTION
- Set `DUCKDB_HTTPSERVER_FOREGROUND` ENV to enable same thread execution

## Todo
- [x] Use ENV `DUCKDB_HTTPSERVER_FOREGROUND`
- [x] Terminate with SIGINT